### PR TITLE
be Scala 2.13 friendly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,12 @@ lazy val sourcecode = crossProject.settings(
   organization := "com.lihaoyi",
   libraryDependencies ++= macroDependencies(scalaVersion.value),
   unmanagedSourceDirectories in Compile ++= {
-    if (scalaVersion.value startsWith "2.12.") Seq(baseDirectory.value / ".."/"shared"/"src"/ "main" / "scala-2.11")
-    else Seq()
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n >= 12 =>
+        Seq(baseDirectory.value / ".."/"shared"/"src"/ "main" / "scala-2.11")
+      case _ =>
+        Seq()
+    }
   },
   publishTo := Some("releases"  at "https://oss.sonatype.org/service/local/staging/deploy/maven2"),
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13


### PR DESCRIPTION
although the 2.13 effort is only just getting underway, we do already
have a Scala 2.13 community build, and this fixes the build to work
in that context

also bump sbt version to latest, for good measure