### PR TITLE
add osgi headers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val sourcecode = crossProject.settings(
 ).enablePlugins(SbtOsgi).settings(osgiSettings).settings(
   exportPackage := Seq("sourcecode.*"),
   privatePackage := Seq(),
-  dynamicImportPackage := Seq("*"),
+  dynamicImportPackage := Seq("*")
 )
 
 lazy val js = sourcecode.js

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import OsgiKeys._
 
 crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0")
 
@@ -13,7 +14,7 @@ def macroDependencies(version: String) =
       Seq())
 
 lazy val sourcecode = crossProject.settings(
-  version := "0.1.3",
+  version := "0.1.4",
   scalaVersion := "2.11.8",
   name := "sourcecode"  ,
   organization := "com.lihaoyi",
@@ -47,6 +48,10 @@ lazy val sourcecode = crossProject.settings(
         <url>https://github.com/lihaoyi</url>
       </developer>
     </developers>
+).enablePlugins(SbtOsgi).settings(osgiSettings).settings(
+  exportPackage := Seq("sourcecode.*"),
+  privatePackage := Seq(),
+  dynamicImportPackage := Seq("*"),
 )
 
 lazy val js = sourcecode.js

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.13")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")


### PR DESCRIPTION
This adds OSGi headers to the jar manifests, which I need downstream to support OSGi in doobie. The end result is that `META-INF/MANIFEST.MF` now looks like:

```
Manifest-Version: 1.0
Bnd-LastModified: 1498590525574
Bundle-Description: sourcecode
Bundle-ManifestVersion: 2
Bundle-Name: sourcecode
Bundle-SymbolicName: com.lihaoyi.sourcecode
Bundle-Vendor: com.lihaoyi
Bundle-Version: 0.1.4
Created-By: 1.8.0_65 (Oracle Corporation)
DynamicImport-Package: *
Export-Package: sourcecode;uses:="scala,scala.collection,scala.collectio
 n.immutable,scala.reflect,scala.reflect.api,scala.reflect.macros.blackb
 ox,scala.runtime";version="0.1.4.SNAPSHOT"
Import-Package: scala;version="[2.12,3)",scala.collection;version="[2.12
 ,3)",scala.collection.generic;version="[2.12,3)",scala.collection.immut
 able;version="[2.12,3)",scala.collection.mutable;version="[2.12,3)",sca
 la.math;version="[2.12,3)",scala.reflect;version="[2.12,3)",scala.refle
 ct.api;version="[2.12,3)",scala.reflect.internal;version="[2.12,3)",sca
 la.reflect.internal.util;version="[2.12,3)",scala.reflect.macros,scala.
 reflect.macros.blackbox;version="[2.12,3)",scala.reflect.macros.context
 s;version="[2.12,3)",scala.runtime;version="[2.12,3)",scala.tools.nsc;v
 ersion="[2.12,3)",scala.tools.nsc.ast.parser;version="[2.12,3)"
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
Tool: Bnd-2.4.0.201411031534
```