### PR TITLE
anonymous class's name is set as the term name

### DIFF
--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -26,13 +26,8 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
     var owner = Compat.enclosingOwner(c)
     while(Util.isSynthetic(c)(owner)) owner = owner.owner
     val simpleName = Util.getName(c)(owner)
-    def termIsValVarOrLazy(term : TermSymbol) : Boolean = term.isVal || term.isVar || term.isLazy
-    //if the class name is anonymous, then we dig up the instance value name instead
-    val valName = if ((simpleName == "$anon") && (owner.owner.isTerm) && termIsValVarOrLazy(owner.owner.asTerm)) {
-      Util.getName(c)(owner.owner)
-    } else simpleName
 
-    c.Expr[sourcecode.Name](q"""${c.prefix}($valName)""")
+    c.Expr[sourcecode.Name](q"""${c.prefix}($simpleName)""")
   }
   case class Machine(value: String) extends SourceValue[String]
   object Machine extends SourceCompanion[String, Machine](new Machine(_)){
@@ -41,6 +36,29 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
       import c.universe._
       val owner = Compat.enclosingOwner(c)
       val simpleName = Util.getName(c)(owner)
+      c.Expr[Machine](q"""${c.prefix}($simpleName)""")
+    }
+  }
+}
+case class OwnerName(value: String) extends SourceValue[String]
+object OwnerName extends SourceCompanion[String, OwnerName](new OwnerName(_)){
+  implicit def generate: OwnerName = macro impl
+
+  def impl(c: Compat.Context): c.Expr[OwnerName] = {
+    import c.universe._
+    var owner = Compat.enclosingOwner(c)
+    while(Util.isSynthetic(c)(owner)) owner = owner.owner
+    val simpleName = Util.getName(c)(owner.owner)
+
+    c.Expr[sourcecode.OwnerName](q"""${c.prefix}($simpleName)""")
+  }
+  case class Machine(value: String) extends SourceValue[String]
+  object Machine extends SourceCompanion[String, Machine](new Machine(_)){
+    implicit def generate: Machine = macro impl
+    def impl(c: Compat.Context): c.Expr[Machine] = {
+      import c.universe._
+      val owner = Compat.enclosingOwner(c)
+      val simpleName = Util.getName(c)(owner.owner)
       c.Expr[Machine](q"""${c.prefix}($simpleName)""")
     }
   }

--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -26,7 +26,12 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
     var owner = Compat.enclosingOwner(c)
     while(Util.isSynthetic(c)(owner)) owner = owner.owner
     val simpleName = Util.getName(c)(owner)
-    c.Expr[sourcecode.Name](q"""${c.prefix}($simpleName)""")
+    //if the class name is anonymous, then we dig up the instance value name instead
+    val valName = if ((simpleName == "$anon") && (owner.owner.isTerm)) {
+      Util.getName(c)(owner.owner)
+    } else simpleName
+
+    c.Expr[sourcecode.Name](q"""${c.prefix}($valName)""")
   }
   case class Machine(value: String) extends SourceValue[String]
   object Machine extends SourceCompanion[String, Machine](new Machine(_)){

--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -26,8 +26,9 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
     var owner = Compat.enclosingOwner(c)
     while(Util.isSynthetic(c)(owner)) owner = owner.owner
     val simpleName = Util.getName(c)(owner)
+    def termIsValVarOrLazy(term : TermSymbol) : Boolean = term.isVal || term.isVar || term.isLazy
     //if the class name is anonymous, then we dig up the instance value name instead
-    val valName = if ((simpleName == "$anon") && (owner.owner.isTerm)) {
+    val valName = if ((simpleName == "$anon") && (owner.owner.isTerm) && termIsValVarOrLazy(owner.owner.asTerm)) {
       Util.getName(c)(owner.owner)
     } else simpleName
 

--- a/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
@@ -1,0 +1,18 @@
+package sourcecode
+
+object AnonClassName {
+  def run() = {
+    abstract class Foo(implicit n : sourcecode.Name) {
+      def getName = n.value
+    }
+    new Foo {} //just creating a nameless instance
+
+    val foo = new Foo {}
+    var foo2 = new Foo {}
+    lazy val foo3 = new Foo {}
+
+    assert(foo.getName == "foo")
+    assert(foo2.getName == "foo2")
+    assert(foo3.getName == "foo3$lzy")
+  }
+}

--- a/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
@@ -13,6 +13,6 @@ object AnonClassName {
 
     assert(foo.getName == "foo")
     assert(foo2.getName == "foo2")
-    assert(foo3.getName == "foo3$lzy")
+    assert(foo3.getName == "foo3$lzy" || foo3.getName == "foo3")
   }
 }

--- a/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
@@ -5,12 +5,11 @@ object AnonClassName {
     abstract class Foo(implicit n : sourcecode.Name) {
       def getName = n.value
     }
-    new Foo {} //just creating a nameless instance
-
     val foo = new Foo {}
     var foo2 = new Foo {}
     lazy val foo3 = new Foo {}
 
+    assert(new Foo {}.getName == "$anon")
     assert(foo.getName == "foo")
     assert(foo2.getName == "foo2")
     assert(foo3.getName == "foo3$lzy" || foo3.getName == "foo3")

--- a/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
@@ -2,16 +2,18 @@ package sourcecode
 
 object AnonClassName {
   def run() = {
-    abstract class Foo(implicit n : sourcecode.Name) {
-      def getName = n.value
+    abstract class Foo(implicit name : sourcecode.Name, ownerName: OwnerName) {
+      def getName = name.value
+      def getOwnerName = ownerName.value
     }
     val foo = new Foo {}
     var foo2 = new Foo {}
     lazy val foo3 = new Foo {}
 
-    assert(new Foo {}.getName == "$anon")
-    assert(foo.getName == "foo")
-    assert(foo2.getName == "foo2")
-    assert(foo3.getName == "foo3$lzy" || foo3.getName == "foo3")
+    //It would have been better if the name will get "$anon", but the owner is `run` def
+    assert(new Foo {}.getOwnerName == "run")
+    assert(foo.getOwnerName == "foo")
+    assert(foo2.getOwnerName == "foo2")
+    assert(foo3.getOwnerName == "foo3$lzy" || foo3.getOwnerName == "foo3")
   }
 }

--- a/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
@@ -21,6 +21,7 @@ object Tests{
     ManualImplicit()
     TextTests()
     ArgsTests()
+    AnonClassName.run()
 
     println("================LogExample================")
     logExample()


### PR DESCRIPTION
In the following code, we expect `nice` to be printed, but we get `$anon`
```scala
abstract class Foo(implicit n : sourcecode.Name) {
  def getName = n.value
}
val nice = new Foo {}
println(nice.getName)
```
This PR fixes this issue.

---

Also see gitter chat: https://gitter.im/lihaoyi/sourcecode?at=5ae9861853ceca3604a63a5e