### PR TITLE
Add Automatic-Module-Name for Java 9 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,10 @@ lazy val sourcecode = crossProject(JSPlatform, JVMPlatform, NativePlatform)
           Seq()
       }
     },
+    // Java 9 settings
+    packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+      "Automatic-Module-Name" -> "com.lihaoyi.sourcecode"
+    ),
     // Osgi settings
     osgiSettings,
     exportPackage := Seq("sourcecode.*"),


### PR DESCRIPTION
This adds an [`Automatic-Module-Name`](http://branchandbound.net/blog/java/2017/12/automatic-module-name/) to the JAR manifest, allowing the library to be used on the Java 9 module path.

If the library was used before on the Java 9 module path, the module name was derived from the filename of the JAR at runtime to `sourcecode.2.12`, which is not a valid Java identifier.