### PR TITLE
Added OwnerName

### DIFF
--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -39,7 +39,19 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
       c.Expr[Machine](q"""${c.prefix}($simpleName)""")
     }
   }
+  case class Of[T](value: String) extends SourceValue[String]
+  object Of extends SourceCompanion[String, Of[_]](new Of(_)){
+    implicit def generate[T]: Of[T] = macro impl[T]
+
+    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[Of[T]] = {
+      import c.universe._
+      val sym = symbolOf[T]
+      val simpleName = sym.name.toString
+      c.Expr[sourcecode.Name.Of[T]](q"""${c.prefix}($simpleName)""")
+    }
+  }
 }
+
 case class OwnerName(value: String) extends SourceValue[String]
 object OwnerName extends SourceCompanion[String, OwnerName](new OwnerName(_)){
   implicit def generate: OwnerName = macro impl
@@ -86,6 +98,17 @@ object FullName extends SourceCompanion[String, FullName](new FullName(_)){
       val owner = Compat.enclosingOwner(c)
       val fullName = owner.fullName.trim
       c.Expr[Machine](q"""${c.prefix}($fullName)""")
+    }
+  }
+  case class Of[T](value: String) extends SourceValue[String]
+  object Of extends SourceCompanion[String, Of[_]](new Of(_)){
+    implicit def generate[T]: Of[T] = macro impl[T]
+
+    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[Of[T]] = {
+      import c.universe._
+      val sym = symbolOf[T]
+      val simpleName = sym.fullName
+      c.Expr[sourcecode.FullName.Of[T]](q"""${c.prefix}($simpleName)""")
     }
   }
 }

--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -39,15 +39,26 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
       c.Expr[Machine](q"""${c.prefix}($simpleName)""")
     }
   }
-  case class Of[T](value: String) extends SourceValue[String]
-  object Of extends SourceCompanion[String, Of[_]](new Of(_)){
-    implicit def generate[T]: Of[T] = macro impl[T]
+  case class OfType[T](value: String) extends SourceValue[String]
+  object OfType extends SourceCompanion[String, OfType[_]](new OfType(_)){
+    implicit def generate[T]: OfType[T] = macro impl[T]
 
-    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[Of[T]] = {
+    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[OfType[T]] = {
+      import c.universe._
+      val sym = weakTypeOf[T]
+      val simpleName = sym.toString
+      c.Expr[sourcecode.Name.OfType[T]](q"""${c.prefix}($simpleName)""")
+    }
+  }
+  case class OfSymbol[T](value: String) extends SourceValue[String]
+  object OfSymbol extends SourceCompanion[String, OfSymbol[_]](new OfSymbol(_)){
+    implicit def generate[T]: OfSymbol[T] = macro impl[T]
+
+    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[OfSymbol[T]] = {
       import c.universe._
       val sym = symbolOf[T]
       val simpleName = sym.name.toString
-      c.Expr[sourcecode.Name.Of[T]](q"""${c.prefix}($simpleName)""")
+      c.Expr[sourcecode.Name.OfSymbol[T]](q"""${c.prefix}($simpleName)""")
     }
   }
 }
@@ -100,15 +111,15 @@ object FullName extends SourceCompanion[String, FullName](new FullName(_)){
       c.Expr[Machine](q"""${c.prefix}($fullName)""")
     }
   }
-  case class Of[T](value: String) extends SourceValue[String]
-  object Of extends SourceCompanion[String, Of[_]](new Of(_)){
-    implicit def generate[T]: Of[T] = macro impl[T]
+  case class OfSymbol[T](value: String) extends SourceValue[String]
+  object OfSymbol extends SourceCompanion[String, OfSymbol[_]](new OfSymbol(_)){
+    implicit def generate[T]: OfSymbol[T] = macro impl[T]
 
-    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[Of[T]] = {
+    def impl[T](c: Compat.Context)(implicit t : c.WeakTypeTag[T]): c.Expr[OfSymbol[T]] = {
       import c.universe._
       val sym = symbolOf[T]
       val simpleName = sym.fullName
-      c.Expr[sourcecode.FullName.Of[T]](q"""${c.prefix}($simpleName)""")
+      c.Expr[sourcecode.FullName.OfSymbol[T]](q"""${c.prefix}($simpleName)""")
     }
   }
 }

--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -26,6 +26,7 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
     var owner = Compat.enclosingOwner(c)
     while(Util.isSynthetic(c)(owner)) owner = owner.owner
     val simpleName = Util.getName(c)(owner)
+
     c.Expr[sourcecode.Name](q"""${c.prefix}($simpleName)""")
   }
   case class Machine(value: String) extends SourceValue[String]
@@ -35,6 +36,29 @@ object Name extends SourceCompanion[String, Name](new Name(_)){
       import c.universe._
       val owner = Compat.enclosingOwner(c)
       val simpleName = Util.getName(c)(owner)
+      c.Expr[Machine](q"""${c.prefix}($simpleName)""")
+    }
+  }
+}
+case class OwnerName(value: String) extends SourceValue[String]
+object OwnerName extends SourceCompanion[String, OwnerName](new OwnerName(_)){
+  implicit def generate: OwnerName = macro impl
+
+  def impl(c: Compat.Context): c.Expr[OwnerName] = {
+    import c.universe._
+    var owner = Compat.enclosingOwner(c)
+    while(Util.isSynthetic(c)(owner)) owner = owner.owner
+    val simpleName = Util.getName(c)(owner.owner)
+
+    c.Expr[sourcecode.OwnerName](q"""${c.prefix}($simpleName)""")
+  }
+  case class Machine(value: String) extends SourceValue[String]
+  object Machine extends SourceCompanion[String, Machine](new Machine(_)){
+    implicit def generate: Machine = macro impl
+    def impl(c: Compat.Context): c.Expr[Machine] = {
+      import c.universe._
+      val owner = Compat.enclosingOwner(c)
+      val simpleName = Util.getName(c)(owner.owner)
       c.Expr[Machine](q"""${c.prefix}($simpleName)""")
     }
   }

--- a/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/AnonClassName.scala
@@ -1,0 +1,19 @@
+package sourcecode
+
+object AnonClassName {
+  def run() = {
+    abstract class Foo(implicit name : sourcecode.Name, ownerName: OwnerName) {
+      def getName = name.value
+      def getOwnerName = ownerName.value
+    }
+    val foo = new Foo {}
+    var foo2 = new Foo {}
+    lazy val foo3 = new Foo {}
+
+    //It would have been better if the name will get "$anon", but the owner is `run` def
+    assert(new Foo {}.getOwnerName == "run")
+    assert(foo.getOwnerName == "foo")
+    assert(foo2.getOwnerName == "foo2")
+    assert(foo3.getOwnerName == "foo3$lzy" || foo3.getOwnerName == "foo3")
+  }
+}

--- a/sourcecode/shared/src/test/scala/sourcecode/NameOfTests.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/NameOfTests.scala
@@ -2,13 +2,16 @@ package sourcecode
 
 object NameOfTests {
   def run() = {
-    abstract class Foo[T](implicit name : Name.Of[T], fullName : FullName.Of[T]) {
+    abstract class Foo[T](implicit name : Name.OfSymbol[T], fullName : FullName.OfSymbol[T], typeName : Name.OfType[T]) {
       def getName = name.value
       def getFullName = fullName.value
+      def getTypeName = typeName.value
     }
-    trait TTT
-    val foo = new Foo[TTT] {}
+    trait TTT[T]
+    trait MM
+    val foo = new Foo[TTT[MM]] {}
     assert(foo.getName == "TTT")
     assert(foo.getFullName == "sourcecode.NameOfTests.TTT")
+    assert(foo.getTypeName == "TTT[MM]")
   }
 }

--- a/sourcecode/shared/src/test/scala/sourcecode/NameOfTests.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/NameOfTests.scala
@@ -1,0 +1,14 @@
+package sourcecode
+
+object NameOfTests {
+  def run() = {
+    abstract class Foo[T](implicit name : Name.Of[T], fullName : FullName.Of[T]) {
+      def getName = name.value
+      def getFullName = fullName.value
+    }
+    trait TTT
+    val foo = new Foo[TTT] {}
+    assert(foo.getName == "TTT")
+    assert(foo.getFullName == "sourcecode.NameOfTests.TTT")
+  }
+}

--- a/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
@@ -22,6 +22,7 @@ object Tests{
     TextTests()
     ArgsTests()
     AnonClassName.run()
+    NameOfTests.run()
 
     println("================LogExample================")
     logExample()

--- a/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
+++ b/sourcecode/shared/src/test/scala/sourcecode/Tests.scala
@@ -21,6 +21,7 @@ object Tests{
     ManualImplicit()
     TextTests()
     ArgsTests()
+    AnonClassName.run()
 
     println("================LogExample================")
     logExample()


### PR DESCRIPTION
Instead of #48, this adds `OwnerName`, so the user can create their own logic in case `Name` returns `$anon`.
```scala
abstract class Foo(implicit name : sourcecode.Name, ownerName : sourcecode.OwnerName) {
  def getName = name.value
  def getOwnerName = ownerName.value
}
val nice = new Foo {}
println(nice.getName) //prints `$anon`
println(nice.getOwnerName) //prints `nice`
```
