### PR TITLE
Setup releases from CI

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx8G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,31 @@
 language: scala
-sudo: required
-dist: trusty
-script:
-  # plz is like ++ except it skips projects that are not defined for that scala version.
-  - sbt "plz $TRAVIS_SCALA_VERSION test"
 jdk:
   - oraclejdk8
-scala:
-  - 2.10.7
-  - 2.11.12
-  - 2.12.6
-  - 2.13.0-M5
-env:
-  - SCALAJS_VERSION=0.6.25
-matrix:
+sudo: required
+dist: trusty
+stages:
+  - name: test
+  - name: release
+    if: (branch = master AND type = push) OR (tag IS present)
+script: sbt "++$TRAVIS_SCALA_VERSION test"
+jobs:
   include:
     - scala: 2.10.7
       jdk: openjdk7
-before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+    - scala: 2.10.7
+    - scala: 2.11.12
+      before_install:
+        - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
+    - scala: 2.12.6
+    - scala: 2.13.0-M5
+
+    # Release stable release on tag push and snapshot on merge to master
+    - stage: release
+      script: sbt ci-release
+
 cache:
   directories:
-  - $HOME/.sbt/0.13/dependency
+  - $HOME/.sbt/1.0/dependency
   - $HOME/.sbt/boot/scala*
   - $HOME/.sbt/launchers
   - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,10 @@ jobs:
 
 cache:
   directories:
-  - $HOME/.sbt/1.0/dependency
-  - $HOME/.sbt/boot/scala*
-  - $HOME/.sbt/launchers
+  - $HOME/.sbt/zinc
   - $HOME/.ivy2/cache
   - $HOME/.nvm
+  - $HOME/.coursier
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache
   - du -h -d 2 $HOME/.sbt/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
   - $HOME/.sbt/zinc
   - $HOME/.ivy2/cache
   - $HOME/.nvm
-  - $HOME/.coursier
+  - $HOME/.cache/coursier
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache
   - du -h -d 2 $HOME/.sbt/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ script: sbt "++$TRAVIS_SCALA_VERSION test"
 jobs:
   include:
     - scala: 2.10.7
-      jdk: openjdk7
-    - scala: 2.10.7
     - scala: 2.11.12
       before_install:
         - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x

--- a/build.sbt
+++ b/build.sbt
@@ -8,13 +8,8 @@ val scala213 = "2.13.0-M5"
 val baseSettings = Seq(
   organization := "com.lihaoyi",
   name := "sourcecode",
-  version := "0.1.5-SNAPSHOT",
   scalaVersion := scala211,
   crossScalaVersions := Seq(scala210, scala211, scala212, scala213),
-  scmInfo := Some(ScmInfo(
-    browseUrl = url("https://github.com/lihaoyi/sourcecode"),
-    connection = "scm:git:git@github.com:lihaoyi/sourcecode.git"
-  )),
   homepage := Some(url("https://github.com/lihaoyi/sourcecode")),
   licenses := Seq("MIT" -> url("http://www.opensource.org/licenses/mit-license.html")),
   developers += Developer(
@@ -22,17 +17,11 @@ val baseSettings = Seq(
     id = "lihaoyi",
     name = "Li Haoyi",
     url = url("https://github.com/lihaoyi")
-  ),
-  publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-)
-lazy val noPublish = Seq(
-  publishArtifact := false,
-  publish := {},
-  publishLocal := {}
+  )
 )
 
 baseSettings
-noPublish
+skip in publish := true
 
 def macroDependencies(version: String) =
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,8 @@ val scala210 = "2.10.7"
 val scala211 = "2.11.12"
 val scala212 = "2.12.6"
 val scala213 = "2.13.0-M5"
-val baseSettings = Seq(
+
+inThisBuild(List(
   organization := "com.lihaoyi",
   name := "sourcecode",
   scalaVersion := scala211,
@@ -18,10 +19,10 @@ val baseSettings = Seq(
     name = "Li Haoyi",
     url = url("https://github.com/lihaoyi")
   )
-)
+))
 
-baseSettings
 skip in publish := true
+crossScalaVersions := List() // required for `++2.12.6 test` to ignore native project
 
 def macroDependencies(version: String) =
   Seq(
@@ -36,7 +37,6 @@ def macroDependencies(version: String) =
 
 lazy val sourcecode = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
-    baseSettings,
     libraryDependencies ++= macroDependencies(scalaVersion.value),
     test in Test := (run in Test).toTask("").value,
     unmanagedSourceDirectories in Compile ++= {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.3

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.1

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -4,8 +4,8 @@ val scalaJSVersion =
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.8.0")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.4")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.8")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")


### PR DESCRIPTION
Upgrades the build to sbt 1.2 so that we can use sbt-ci-relase to
automate releases from Travis CI.