### PR TITLE
AnyVal all the things

### DIFF
--- a/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
+++ b/sourcecode/shared/src/main/scala/sourcecode/SourceContext.scala
@@ -1,40 +1,40 @@
 package sourcecode
 
 
-abstract class SourceValue[T]{
+trait SourceValue[T] extends Any{
   def value: T
 }
 abstract class SourceCompanion[T, V <: SourceValue[T]](build: T => V){
   def apply()(implicit s: V): T = s.value
   implicit def wrap(s: T): V = build(s)
 }
-case class Name(value: String) extends SourceValue[String]
+case class Name(value: String) extends AnyVal with SourceValue[String]
 object Name extends SourceCompanion[String, Name](new Name(_)) with NameMacros {
-  case class Machine(value: String) extends SourceValue[String]
+  case class Machine(value: String) extends AnyVal with SourceValue[String]
   object Machine extends SourceCompanion[String, Machine](new Machine(_)) with NameMachineMacros
 }
-case class FullName(value: String) extends SourceValue[String]
+case class FullName(value: String) extends AnyVal with SourceValue[String]
 object FullName extends SourceCompanion[String, FullName](new FullName(_)) with FullNameMacros {
-  case class Machine(value: String) extends SourceValue[String]
+  case class Machine(value: String) extends AnyVal with SourceValue[String]
   object Machine extends SourceCompanion[String, Machine](new Machine(_)) with FullNameMachineMacros
 }
-case class File(value: String) extends SourceValue[String]
+case class File(value: String) extends AnyVal with SourceValue[String]
 object File extends SourceCompanion[String, File](new File(_)) with FileMacros
-case class Line(value: Int) extends SourceValue[Int]
+case class Line(value: Int) extends AnyVal with SourceValue[Int]
 object Line extends SourceCompanion[Int, Line](new Line(_)) with LineMacros
-case class Enclosing(value: String) extends SourceValue[String]
+case class Enclosing(value: String) extends AnyVal with SourceValue[String]
 
 object Enclosing extends SourceCompanion[String, Enclosing](new Enclosing(_)) with EnclosingMacros {
-  case class Machine(value: String) extends SourceValue[String]
+  case class Machine(value: String) extends AnyVal with SourceValue[String]
   object Machine extends SourceCompanion[String, Machine](new Machine(_)) with EnclosingMachineMacros
 }
 
 
-case class Pkg(value: String) extends SourceValue[String]
+case class Pkg(value: String) extends AnyVal with SourceValue[String]
 object Pkg extends SourceCompanion[String, Pkg](new Pkg(_)) with PkgMacros
 
 case class Text[T](value: T, source: String)
 object Text extends TextMacros
 
-case class Args(value: Seq[Seq[Text[_]]]) extends SourceValue[Seq[Seq[Text[_]]]]
+case class Args(value: Seq[Seq[Text[_]]]) extends AnyVal with SourceValue[Seq[Seq[Text[_]]]]
 object Args extends SourceCompanion[Seq[Seq[Text[_]]], Args](new Args(_)) with ArgsMacros


### PR DESCRIPTION
This should greatly reduce the allocation of unnecessary boxes where sourcecode is used heavily, e.g. in FastParse parsers

Seems to reduce the fastparse `demo-opt.js` file size from 2,325,565 to 2,285,978 bytes, a reduction of 1.7% (probably less under gzip). Perf tests TBD

Note that this is a binary breaking change; not sure if it's worth doing now. If it doesn't maybe we should just wait until Dotty and just remember to AnyVal things then.

Benchmark Results:

Pass

| Speedup      | Name             | Avg    | StdDev      | Run1 | Run2 | Run3 | Run4 | Run5 |
|--------------|------------------|-------:|------------:|-----:|-----:|-----:|-----:|-----:|  
| 1.004588775  | JsonParse New    | 1138.4 | 76.99545441 | 1272 | 1101 | 1076 | 1121 | 1122 | 
| 0.9975210709 | PythonParse New  | 402.4  | 25.76431641 | 363  | 424  | 427  | 401  | 397  | 
| 1.014749263  | CssParse New     | 412.8  | 8.814760348 | 428  | 410  | 405  | 410  | 411  | 
| 1.039881832  | ScalaParse New   | 281.6  | 17.03819239 | 312  | 272  | 275  | 274  | 275  | 
| 1.00468241   | JsonnetParse New | 3948   | 162.6960356 | 3657 | 4019 | 4018 | 4025 | 4021 | 
|              | JsonParse Old    | 1133.2 | 85.00117646 | 1285 | 1087 | 1097 | 1097 | 1100 | 
|              | PythonParse Old  | 403.4  | 26.23547217 | 362  | 435  | 409  | 405  | 406  | 
|              | CssParse Old     | 406.8  | 22.67597848 | 445  | 393  | 387  | 406  | 403  | 
|              | ScalaParse Old   | 270.8  | 14.48102206 | 294  | 254  | 269  | 267  | 270  | 
|              | JsonnetParse Old | 3929.6 | 71.79345374 | 4046 | 3929 | 3854 | 3926 | 3893 | 

Failure

| Speedup | Name         | Avg              | StdDev | Run1        | Run2 | Run3 | Run4 | Run5 |
|--------------|------------------|-------:|------------:|-----:|-----:|-----:|-----:|-----:| 
| 1.023162939  | JsonParse New    | 256.2  | 14.0605832  | 235  | 255  | 268  | 270  | 253  | 
| 0.9625984252 | PythonParse New  | 97.8   | 14.6355731  | 73   | 112  | 100  | 102  | 102  | 
| 1.032738095  | CssParse New     | 69.4   | 7.503332593 | 56   | 72   | 73   | 73   | 73   | 
| 1.067357513  | ScalaParse New   | 41.2   | 6.260990337 | 30   | 44   | 44   | 44   | 44   | 
| 0.9726922433 | JsonnetParse New | 1161.2 | 65.14368734 | 1084 | 1207 | 1210 | 1209 | 1096 | 
|              |                  |        |             |      |      |      |      |      | 
|              | JsonParse Old    | 250.4  | 15.33949152 | 224  | 250  | 259  | 258  | 261  | 
|              | PythonParse Old  | 101.6  | 15.19210321 | 76   | 114  | 112  | 104  | 102  | 
|              | CssParse Old     | 67.2   | 8.043631021 | 54   | 65   | 72   | 72   | 73   | 
|              | ScalaParse Old   | 38.6   | 9.864076237 | 21   | 44   | 43   | 42   | 43   | 
|              | JsonnetParse Old | 1193.8 | 62.51959693 | 1083 | 1207 | 1227 | 1224 | 1228 | 


Seems like a pretty marginal improvement; probably not worth the backwards compatibility breakage for now