### PR TITLE
Treat $anonfun as synthetic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ object Implicits {
 }
 ```
 
-By default, the various implicits all ignore any synthetic `<init>` or 
-`<local Foo>` methods that might be present:
+By default, the various implicits all ignore any synthetic `<init>`,  
+`<local Foo>` or `$anonfun` methods that might be present:
 
 ```scala
 package sourcecode

--- a/sourcecode/src-0/sourcecode/Macros.scala
+++ b/sourcecode/src-0/sourcecode/Macros.scala
@@ -67,7 +67,7 @@ trait ArgsMacros {
 object Util{
   def isSynthetic(c: Reflection)(s: c.Symbol) = isSyntheticName(getName(c)(s))
   def isSyntheticName(name: String) = {
-    name == "<init>" || (name.startsWith("<local ") && name.endsWith(">"))
+    name == "<init>" || (name.startsWith("<local ") && name.endsWith(">")) || name == "$anonfun"
   }
   def getName(c: Reflection)(s: c.Symbol) = {
     import c.given

--- a/sourcecode/src-2/sourcecode/Macros.scala
+++ b/sourcecode/src-2/sourcecode/Macros.scala
@@ -54,7 +54,7 @@ trait ArgsMacros {
 object Util{
   def isSynthetic(c: Compat.Context)(s: c.Symbol) = isSyntheticName(getName(c)(s))
   def isSyntheticName(name: String) = {
-    name == "<init>" || (name.startsWith("<local ") && name.endsWith(">"))
+    name == "<init>" || (name.startsWith("<local ") && name.endsWith(">")) || name == "$anonfun"
   }
   def getName(c: Compat.Context)(s: c.Symbol) = s.name.decoded.toString.trim
 }

--- a/sourcecode/test/src/sourcecode/NoSynthetic.scala
+++ b/sourcecode/test/src/sourcecode/NoSynthetic.scala
@@ -13,6 +13,13 @@ object NoSynthetic {
       assert(sourcecode.Name() == "Bar")
       assert(sourcecode.FullName() == "sourcecode.NoSynthetic.Bar")
       assert(sourcecode.Enclosing() == "sourcecode.NoSynthetic.run Bar")
+      assert(
+        (for {
+          _ <- Option(1)
+          _ <- Option(2)
+          foo <- Option(sourcecode.Enclosing())
+        } yield foo) == Some("sourcecode.NoSynthetic.run Bar")
+      )
     }
     Bar
   }


### PR DESCRIPTION
This will drop `$anonfun` from Enclosing in for loops etc.

This is really problematic when you have big for expressions. End result will be a lot of `$anonfun`s as for loops get desugared into a bunch of flatmaps.

fixes #39