### PR TITLE
Add support for Scala.js 1.0.0-RC2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -85,7 +85,8 @@ object sourcecode extends Module {
   }
 
   object js extends Cross[JsSourcecodeModule](
-    ("2.11.12", "0.6.28"), ("2.12.10", "0.6.28"), ("2.13.1", "0.6.28")/*, ("2.12.10", "1.0.0-M8"), ("2.13.1", "1.0.0-M8")*/
+    ("2.11.12", "0.6.28"), ("2.12.10", "0.6.28"), ("2.13.1", "0.6.28"),
+    ("2.11.12", "1.0.0-RC2"), ("2.12.10", "1.0.0-RC2"), ("2.13.1", "1.0.0-RC2")
   )
   class JsSourcecodeModule(val crossScalaVersion: String, crossJSVersion: String)
     extends SourcecodeMainModule with ScalaJSModule with SourcecodeModule {

--- a/build.sc
+++ b/build.sc
@@ -64,7 +64,7 @@ trait SourcecodeTestModule extends ScalaModule {
 }
 
 object sourcecode extends Module {
-  object jvm extends Cross[JvmSourcecodeModule]("2.11.12", "2.12.8", "2.13.0", "0.21.0-RC1")
+  object jvm extends Cross[JvmSourcecodeModule]("2.11.12", "2.12.10", "2.13.1", "0.21.0-RC1")
   class JvmSourcecodeModule(val crossScalaVersion: String)
     extends SourcecodeMainModule with ScalaModule with SourcecodeModule {
 
@@ -85,7 +85,7 @@ object sourcecode extends Module {
   }
 
   object js extends Cross[JsSourcecodeModule](
-    ("2.11.12", "0.6.28"), ("2.12.8", "0.6.28"), ("2.13.0", "0.6.28")/*, ("2.12.8", "1.0.0-M8"), ("2.13.0", "1.0.0-M8")*/
+    ("2.11.12", "0.6.28"), ("2.12.10", "0.6.28"), ("2.13.1", "0.6.28")/*, ("2.12.10", "1.0.0-M8"), ("2.13.1", "1.0.0-M8")*/
   )
   class JsSourcecodeModule(val crossScalaVersion: String, crossJSVersion: String)
     extends SourcecodeMainModule with ScalaJSModule with SourcecodeModule {

--- a/mill
+++ b/mill
@@ -3,7 +3,7 @@
 # This is a wrapper script, that automatically download mill from GitHub release pages
 # You can give the required mill version with MILL_VERSION env variable
 # If no version is given, it falls back to the value of DEFAULT_MILL_VERSION
-DEFAULT_MILL_VERSION=0.5.0
+DEFAULT_MILL_VERSION=0.5.7
 
 set -e
 
@@ -17,13 +17,24 @@ if [ -z "$MILL_VERSION" ] ; then
   fi
 fi
 
-MILL_DOWNLOAD_PATH="$HOME/.mill/download"
-MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/$MILL_VERSION"
+if [ "x${XDG_CACHE_HOME}" != "x" ] ; then
+  MILL_DOWNLOAD_PATH="${XDG_CACHE_HOME}/mill/download"
+else
+  MILL_DOWNLOAD_PATH="${HOME}/.cache/mill/download"
+fi
+MILL_EXEC_PATH="${MILL_DOWNLOAD_PATH}/${MILL_VERSION}"
+
+version_remainder="$MILL_VERSION"
+MILL_MAJOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
+MILL_MINOR_VERSION="${version_remainder%%.*}"; version_remainder="${version_remainder#*.}"
 
 if [ ! -x "$MILL_EXEC_PATH" ] ; then
   mkdir -p $MILL_DOWNLOAD_PATH
+  if [ "$MILL_MAJOR_VERSION" -gt 0 ] || [ "$MILL_MINOR_VERSION" -ge 5 ] ; then
+    ASSEMBLY="-assembly"
+  fi
   DOWNLOAD_FILE=$MILL_EXEC_PATH-tmp-download
-  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION-assembly"
+  MILL_DOWNLOAD_URL="https://github.com/lihaoyi/mill/releases/download/${MILL_VERSION%%-*}/$MILL_VERSION${ASSEMBLY}"
   curl --fail -L -o "$DOWNLOAD_FILE" "$MILL_DOWNLOAD_URL"
   chmod +x "$DOWNLOAD_FILE"
   mv "$DOWNLOAD_FILE" "$MILL_EXEC_PATH"

--- a/sourcecode/test/src/sourcecode/Apply.scala
+++ b/sourcecode/test/src/sourcecode/Apply.scala
@@ -24,7 +24,11 @@ object Apply {
     assert(line == 23)
 
     lazy val myLazy = {
-      trait Bar{
+      /* Bar used to be a trait, but that ran into the upstream bug
+       * https://github.com/scala-js/scala-js/issues/3918 in Scala.js 1.0.0-RC2
+       * and Scala 2.12+. We use an abstract class as a workaround.
+       */
+      abstract class Bar{
         val name = sourcecode.Name()
         assert(name == "name")
 
@@ -38,7 +42,7 @@ object Apply {
         assert(fileName == "Apply.scala")
 
         val line = sourcecode.Line()
-        assert(line == 40)
+        assert(line == 44)
 
         val enclosing = sourcecode.Enclosing()
         assert(

--- a/sourcecode/test/src/sourcecode/Implicits.scala
+++ b/sourcecode/test/src/sourcecode/Implicits.scala
@@ -24,7 +24,11 @@ object Implicits {
     assert(line.value == 23)
 
     lazy val myLazy = {
-      trait Bar{
+      /* Bar used to be a trait, but that ran into the upstream bug
+       * https://github.com/scala-js/scala-js/issues/3918 in Scala.js 1.0.0-RC2
+       * and Scala 2.12+. We use an abstract class as a workaround.
+       */
+      abstract class Bar{
         val name = implicitly[sourcecode.Name]
         assert(name.value == "name")
 
@@ -41,7 +45,7 @@ object Implicits {
         assert(fileName.value == "Implicits.scala")
 
         val line = implicitly[sourcecode.Line]
-        assert(line.value == 43)
+        assert(line.value == 47)
 
         val enclosing = implicitly[sourcecode.Enclosing]
         assert(


### PR DESCRIPTION
Note the workaround for https://github.com/scala-js/scala-js/issues/3918 in the tests. @lihaoyi could you check that changing from `trait` to `abstract class` does not annihilate the original purpose of the test? I traced it back all the way to the [first commit](https://github.com/lihaoyi/sourcecode/commit/987f6c567594b3f832ee3adcd013cd9fe484d3a0#diff-1ba6279d17e44160dacaf0bd4dc5deda), so I can't tell whether the test was specifically designed to address some corner case of a *trait* inside a lazy val.