### PR TITLE
Making file path splitting logic use cross platform path separator character

### DIFF
--- a/sourcecode/src-2/sourcecode/Macros.scala
+++ b/sourcecode/src-2/sourcecode/Macros.scala
@@ -117,7 +117,7 @@ object Macros {
     val fileName = filePrefixCache
       .computeIfAbsent(c.enclosingPosition.source, source => findOriginalFile(source.content))
       .getOrElse(c.enclosingPosition.source.path)
-      .split('/').last
+      .split(java.io.File.pathSeparatorChar).last
     c.Expr[sourcecode.FileName](q"""${c.prefix}($fileName)""")
   }
 

--- a/sourcecode/src-3/sourcecode/Macros.scala
+++ b/sourcecode/src-3/sourcecode/Macros.scala
@@ -181,7 +181,7 @@ object Macros {
     val file = filePrefixCache.computeIfAbsent(sourceFile, _ => findOriginalFile(sourceFile.content))
       .getOrElse(sourceFile.path)
 
-    val name = file.split('/').last
+    val name = file.split(java.io.File.pathSeparatorChar).last
 
     '{new sourcecode.FileName(${Expr(name)})}
   }


### PR DESCRIPTION
Fixes: #93 

Making file path splitting logic use cross platform path separator character instead of assuming Unix path separator